### PR TITLE
Add support for ssl_no_verify, root_ca and server_cert/key

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ In your Fluentd configuration, use `@type loki`. Additional configuration is opt
   username "#{ENV['LOKI_USERNAME']}"
   password "#{ENV['LOKI_PASSWORD']}"
   extra_labels {"env":"dev"}
+  
+  ssl_no_verify   false  # default: false
+  cacert_file     /etc/ssl/endpoint1.cert # default: ''
+  client_cert_path /path/to/client_cert.crt # default: ''
+  private_key_path /path/to/private_key.key # default: ''
+  private_key_passphrase yourpassphrase # default: ''
+  
   <buffer>
     flush_interval 10s
     chunk_limit_size 1m


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
I added a few more SSL options like in fluent-elasticsearch-plugin


### Why?
Having loki running behind a loadbalancer that terminates SSL with a corporate root ca. Also obliged to use SSL only connections.

### Additional context
Couldn't get the test running (rake test) but thats due to my local setup, that seems far from perfect.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [-] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] If the PR is not complete but you want to discuss the approach, list what remains to be done here
   - as mentioned above couldn't successfully run the test (ruby newby)